### PR TITLE
Fix Akka HTTP docs links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -173,12 +173,12 @@ redirect_from: "/downloads"
         <div class="docMeta">
           <div class="docMetaContent">
             <h2>Scala</h2>
-            <a href="http://doc.akka.io/docs/akka-http/current/scala.html">Reference</a>
+            <a href="http://doc.akka.io/docs/akka-http/current/scala/http/index.html">Reference</a>
             <a href="http://doc.akka.io/api/akka-http/current/akka/http/scaladsl/index.html">API</a>
           </div>
           <div class="docMetaContent">
             <h2>Java</h2>
-            <a href="http://doc.akka.io/docs/akka-http/current/java.html">Reference</a>
+            <a href="http://doc.akka.io/docs/akka-http/current/java/http/index.html">Reference</a>
             <a href="http://doc.akka.io/japi/akka-http/current/">API</a>
           </div>
         </div>


### PR DESCRIPTION
Links to Akka HTTP point to a non (anymore) existing URL.